### PR TITLE
Fix auth prevention of Beach Show page

### DIFF
--- a/frontend/src/components/app.js
+++ b/frontend/src/components/app.js
@@ -21,7 +21,7 @@ const App = () => (
             {/* <ProtectedRoute exact path="/reviews/:beach_id" component={ReviewsContainer} /> */}
             <ProtectedRoute exact path="/profile" component={ProfileContainer} />
             <ProtectedRoute exact path="/new_review" component={ReviewComposeContainer} />
-            <ProtectedRoute path="/beaches/:beach_id" component={BeachShowContainer} />
+            <Route path="/beaches/:beach_id" component={BeachShowContainer} />
         </Switch>
     </div>
 );


### PR DESCRIPTION
Beach show page should be accessible without registration.
Review posting should not. To be fixed in a following commit.